### PR TITLE
evm_passthrough plugin without Api-Key 

### DIFF
--- a/exr/__init__.py
+++ b/exr/__init__.py
@@ -148,7 +148,7 @@ def handle_payment(payment_tx: str, env: dict):
         res = requests.post(rpcurl, headers=headers, data=payload)
         enforce = uwsgi.opt.get('HANDLE_PAYMENTS_ENFORCE', b'false').decode('utf8')
         # look for valid tx hash in response otherwise fail the check
-        if enforce is 'true' or enforce is '1':
+        if enforce == 'true' or enforce == '1':
             payment_response = res.content.decode('utf8')
             if len(payment_response) != 32 or 'error' in payment_response:
                 logging.info('Failed to process payment from client: {} Error: {} tx hex: {}',

--- a/plugins/evm_passthrough/routes.py
+++ b/plugins/evm_passthrough/routes.py
@@ -172,7 +172,7 @@ def xrouter_call():
     # ["project_id", "method", "[parameters...]"]
     if isinstance(json_data, list) and len(json_data) >= 3:
         project_id = json_data[0]
-        if project_id is None or project_id is '':
+        if project_id == None or project_id == '':
             return bad_request_error('Invalid project id')
         data = util.make_jsonrpc_data(json_data)
         if not data:

--- a/plugins/projects/middleware.py
+++ b/plugins/projects/middleware.py
@@ -76,7 +76,7 @@ def api_error_msg(msg: str, code: ApiError):
 def authenticate(f):
     @wraps(f)
     def wrapper(*args, **kwargs):
-        logging.debug(f'{request.headers} {request.view_args['project_id']}')
+        logging.debug(f'{request.headers} {request.view_args["project_id"]}')
         if 'help' not in request.base_url and 'evm_passthrough' not in request.base_url:
             if 'Api-Key' not in request.headers:
                 return api_error_msg('Missing Api-Key header', ApiError.MISSING_API_KEY)

--- a/plugins/projects/middleware.py
+++ b/plugins/projects/middleware.py
@@ -76,20 +76,27 @@ def api_error_msg(msg: str, code: ApiError):
 def authenticate(f):
     @wraps(f)
     def wrapper(*args, **kwargs):
-        logging.debug('%s %s', request.headers.get('Api-Key'), request.view_args['project_id'])
-        if 'help' not in request.base_url:
+        logging.debug(f'{request.headers} {request.view_args['project_id']}')
+        if 'help' not in request.base_url and 'evm_passthrough' not in request.base_url:
             if 'Api-Key' not in request.headers:
                 return api_error_msg('Missing Api-Key header', ApiError.MISSING_API_KEY)
         if 'project_id' not in request.view_args:
             return api_error_msg('Missing project-id in url', ApiError.MISSING_PROJECT_ID)
 
         project_id = request.view_args['project_id']
-        if 'help' not in request.base_url:
+        if 'help' not in request.base_url and 'evm_passthrough' not in request.base_url:
             api_key = request.headers.get('Api-Key')
 
         with db_session:
-            if 'help' in request.base_url:
-                project = Project.get(name=project_id)
+            if 'help' in request.base_url or 'evm_passthrough' in request.base_url:
+                if 'evm_passthrough' in request.base_url:
+                    if 'Api-Key' in request.headers:
+                        api_key = request.headers.get('Api-Key')
+                        project = Project.get(name=project_id, api_key=api_key)
+                    else:
+                        project = Project.get(name=project_id)    
+                else:
+                    project = Project.get(name=project_id)
             else:
                 project = Project.get(name=project_id, api_key=api_key)
 


### PR DESCRIPTION
`evm_passthrough` should work with paid `project_id` and missing `Api-Key` from headers.

- [x] test if a paid project has a successful request without `Api-Key` in headers