### PR TITLE
Removed final / requirement for Hydra endpoints; improved XQ help text

### DIFF
--- a/plugins/evm_passthrough/routes.py
+++ b/plugins/evm_passthrough/routes.py
@@ -48,6 +48,7 @@ def unauthorized_error(error):
     return response
 
 
+@app.route('/xrs/evm_passthrough/<evm>/<project_id>', methods=['POST'], strict_slashes=False)
 @app.route('/xrs/evm_passthrough/<evm>/<project_id>/', methods=['POST'], strict_slashes=False)
 @app.route('/xrs/evm_passthrough/<evm>/<project_id>/<path:path>', methods=['POST'], strict_slashes=False)
 @authenticate
@@ -109,9 +110,9 @@ def handle_request(evm, project_id, path=None):
         host = uwsgi.opt.get(f'{evm.upper()}_HOST_IP', b'localhost').decode('utf8')
         host_ip = uwsgi.opt.get(f'{evm.upper()}_HOST_PORT', b'8545').decode('utf8')
         host = 'http://'+host+':'+host_ip
-        if path and path not in ['','/']:
-            if path[0] == '/':
-                path = path[1::]
+        if path:
+            if path[-1] == '/':
+                path = path[:-1]
             host += f'/{path}'
         eth_user = uwsgi.opt.get(f'{evm.upper()}_HOST_USER', b'').decode('utf8')
         eth_pass = uwsgi.opt.get(f'{evm.upper()}_HOST_PASS', b'').decode('utf8')

--- a/wsgi.py
+++ b/wsgi.py
@@ -29,6 +29,7 @@ def load_plugins():
     plugins = uwsgi.opt.get('PLUGINS', b'').decode('utf8').split(',')
 
     for plugin in plugins:
+        if 'evm_passthrough_' in plugin or 'xquery_' in plugin: continue # these are not real plugins
         try:
             plugin_app = getattr(importlib.import_module(f"plugins.{plugin}.routes"), "app")
             app.register_blueprint(plugin_app)


### PR DESCRIPTION
This PR fixes the issue where Hydra endpoints required a `/` character at the end of the URL for ETH and NEVM Hydra endpoints, and did *not* accept `/` at the end of the URL for AVAX Hydra endpoint. With this PR, final `/` character is optional for all Hydra endpoints.

This PR also improves the help message given by XQ.

It also eliminates some false error messages in `xr_proxy` logs by not trying to load plugins which are not real plugins and only exist as a way of broadcasting which EVMs are supported by XQuery and Hydra.

These changes have been tested and confirmed to work.